### PR TITLE
Fix linux carest wrapper

### DIFF
--- a/SonglistGenerator/CaretsWrapper.cs
+++ b/SonglistGenerator/CaretsWrapper.cs
@@ -33,6 +33,7 @@ namespace SonglistGenerator
                     textToWrap.IndexOf(' ', caret),
                     textToWrap.IndexOf('\\', caret),
                     textToWrap.IndexOf(Environment.NewLine, caret),
+                    textToWrap.IndexOf('\n', caret),
                     textToWrap.IndexOf(')', caret),
                 }.Where(x => x >= 0).Min();
 
@@ -42,6 +43,7 @@ namespace SonglistGenerator
                 {
                     textToWrap.LastIndexOf(' ', caret),
                     textToWrap.LastIndexOf('(', caret),
+                    textToWrap.LastIndexOf('\t', caret),
                 }.Where(x => x >= 0).Max();
 
                 textToWrap = textToWrap.Insert(startOfBracedSection + 1, startWrap);

--- a/SonglistGenerator/CaretsWrapper.cs
+++ b/SonglistGenerator/CaretsWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SonglistGenerator
@@ -31,7 +32,7 @@ namespace SonglistGenerator
                 { 
                     textToWrap.IndexOf(' ', caret),
                     textToWrap.IndexOf('\\', caret),
-                    textToWrap.IndexOf('\n', caret),
+                    textToWrap.IndexOf(Environment.NewLine, caret),
                     textToWrap.IndexOf(')', caret),
                 }.Where(x => x >= 0).Min();
 


### PR DESCRIPTION
Added Environment.NewLine and \t to carets wrapper, to make it working correctly on linux agents (and with wrong tabulator indented songs)